### PR TITLE
Create basic app navigation

### DIFF
--- a/app/[...missing].js
+++ b/app/[...missing].js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { useRouter } from 'expo-router'
+import { Button } from 'react-native-paper'
+
+import Container from '@components/Container'
+
+const NotFound = () => {
+    const router = useRouter()
+
+    return (
+        <Container>
+            <h3>404 - Page Not Found</h3>
+            <Button mode="contained" onPress={() => router.push('/')}>
+                Go Home
+            </Button>
+        </Container>
+    )
+}
+
+export default NotFound

--- a/app/_layout.js
+++ b/app/_layout.js
@@ -3,9 +3,9 @@ import { Stack } from 'expo-router'
 import { PaperProvider } from 'react-native-paper'
 import { Provider } from 'react-redux'
 
-import { store } from '../store'
+import { store } from '@store'
 
-export default function RootLayout() {
+const RootLayout = () => {
     return (
         <Provider store={store}>
             <PaperProvider>
@@ -16,3 +16,5 @@ export default function RootLayout() {
         </Provider>
     )
 }
+
+export default RootLayout

--- a/app/auth/login.js
+++ b/app/auth/login.js
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react'
+import { Button } from 'react-native-paper'
+import { useRouter } from 'expo-router'
+import { useDispatch, useSelector } from 'react-redux'
+
+import AuthPage from '@components/AuthPage'
+import { userLogin, selectIsLoggedIn } from '@store'
+
+const Login = () => {
+    const dispatch = useDispatch()
+    const router = useRouter()
+
+    const isLoggedIn = useSelector(selectIsLoggedIn)
+
+    const onLoginPress = async () => {
+        await dispatch(userLogin)
+    }
+
+    useEffect(() => {
+        if (isLoggedIn) {
+            router.replace('/')
+        }
+    }, [isLoggedIn])
+
+    return (
+        <AuthPage>
+            <span>Login Screen</span>
+            <Button mode="contained" onPress={onLoginPress}>
+                Login
+            </Button>
+        </AuthPage>
+    )
+}
+
+export default Login

--- a/app/buy/index.js
+++ b/app/buy/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import Page from '@components/Page'
+
+const Buy = () => {
+    return (
+        <Page>
+            <p>Buy Page</p>
+        </Page>
+    )
+}
+
+export default Buy

--- a/app/index.js
+++ b/app/index.js
@@ -1,19 +1,41 @@
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
-import { ActivityIndicator } from 'react-native-paper'
+import { Button, Text } from 'react-native-paper'
+import { StyleSheet } from 'react-native'
+import { useRouter } from 'expo-router'
 
-export default function Index() {
+import Page from '@components/Page'
+
+const Index = () => {
+    const router = useRouter()
+
+    const onBuyPress = () => {
+        router.replace('buy/')
+    }
+    const onSellPress = () => {
+        router.replace('sell/')
+    }
+
     return (
-        <View style={styles.container}>
-            <ActivityIndicator animating={true} size="large" color="black" />
-        </View>
+        <Page>
+            <div style={styles.buttonContainer}>
+                <Text>Would you like to...</Text>
+                <Button mode="contained" onPress={onBuyPress}>
+                    Buy
+                </Button>
+                <Button mode="contained" onPress={onSellPress}>
+                    Sell
+                </Button>
+            </div>
+        </Page>
     )
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center'
+    buttonContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem'
     }
 })
+
+export default Index

--- a/app/sell/index.js
+++ b/app/sell/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import Page from '@components/Page'
+
+const Sell = () => {
+    return (
+        <Page>
+            <p>Sell Page</p>
+        </Page>
+    )
+}
+
+export default Sell

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,18 @@ module.exports = function (api) {
             production: {
                 plugins: ['react-native-paper/babel']
             }
-        }
+        },
+        plugins: [
+            [
+                'module-resolver',
+                {
+                    alias: {
+                        '@components': './components',
+                        '@constants': './constants',
+                        '@store': './store'
+                    }
+                }
+            ]
+        ]
     }
 }

--- a/components/AuthPage.js
+++ b/components/AuthPage.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { node } from 'prop-types'
+import { Redirect, useRootNavigationState } from 'expo-router'
+import { useSelector } from 'react-redux'
+
+import { selectIsLoggedIn } from '@store'
+import Container from '@components/Container'
+
+const AuthPage = ({ children }) => {
+    const rootNavigationState = useRootNavigationState()
+    const isLoggedIn = useSelector(selectIsLoggedIn)
+
+    if (!rootNavigationState?.key) {
+        return null
+    }
+
+    if (isLoggedIn) {
+        return <Redirect href="/" />
+    }
+
+    return <Container>{children}</Container>
+}
+
+AuthPage.propTypes = {
+    children: node.isRequired
+}
+
+export default AuthPage

--- a/components/Container.js
+++ b/components/Container.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { node } from 'prop-types'
+import { StyleSheet, View } from 'react-native'
+
+const Container = ({ children }) => {
+    return <View style={styles.container}>{children}</View>
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center'
+    }
+})
+
+Container.propTypes = {
+    children: node.isRequired
+}
+
+export default Container

--- a/components/Page.js
+++ b/components/Page.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { node } from 'prop-types'
+import { Redirect, useRootNavigationState } from 'expo-router'
+import { useSelector } from 'react-redux'
+
+import { selectIsLoggedIn } from '@store'
+import Container from '@components/Container'
+
+const Page = ({ children }) => {
+    const rootNavigationState = useRootNavigationState()
+    const isLoggedIn = useSelector(selectIsLoggedIn)
+
+    if (!rootNavigationState?.key) {
+        return null
+    }
+
+    if (!isLoggedIn) {
+        return <Redirect href="auth/login" />
+    }
+
+    return <Container>{children}</Container>
+}
+
+Page.propTypes = {
+    children: node.isRequired
+}
+
+export default Page

--- a/constants/actions.js
+++ b/constants/actions.js
@@ -1,0 +1,1 @@
+export const SET_USER_LOGIN = 'SET_USER_LOGIN'

--- a/constants/index.js
+++ b/constants/index.js
@@ -1,0 +1,1 @@
+export * from './actions'

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "@types/jest": "^29.5.12",
                 "@types/react": "~18.2.45",
                 "@types/react-test-renderer": "^18.0.7",
+                "babel-plugin-module-resolver": "^5.0.2",
                 "eslint": "^8.57.0",
                 "eslint-plugin-react": "^7.35.0",
                 "globals": "^15.9.0",
@@ -8397,6 +8398,75 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/babel-plugin-module-resolver": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+            "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-babel-config": "^2.1.1",
+                "glob": "^9.3.3",
+                "pkg-up": "^3.1.0",
+                "reselect": "^4.1.7",
+                "resolve": "^1.22.8"
+            }
+        },
+        "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/babel-plugin-module-resolver/node_modules/glob": {
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^8.0.2",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/babel-plugin-module-resolver/node_modules/minimatch": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/babel-plugin-module-resolver/node_modules/minipass": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/babel-plugin-polyfill-corejs2": {
             "version": "0.4.11",
             "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
@@ -11395,6 +11465,16 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
+        },
+        "node_modules/find-babel-config": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+            "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json5": "^2.2.3"
+            }
         },
         "node_modules/find-cache-dir": {
             "version": "2.1.0",
@@ -17739,6 +17819,85 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pkg-up": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+            "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pkg-up/node_modules/find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pkg-up/node_modules/locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pkg-up/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pkg-up/node_modules/p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pkg-up/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/plist": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -18913,6 +19072,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/reselect": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+            "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@types/jest": "^29.5.12",
         "@types/react": "~18.2.45",
         "@types/react-test-renderer": "^18.0.7",
+        "babel-plugin-module-resolver": "^5.0.2",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.35.0",
         "globals": "^15.9.0",

--- a/store/actions/index.js
+++ b/store/actions/index.js
@@ -1,0 +1,1 @@
+export * from './userActions'

--- a/store/actions/userActions.js
+++ b/store/actions/userActions.js
@@ -1,0 +1,7 @@
+import { SET_USER_LOGIN } from '@constants'
+
+export const userLogin = async (dispatch) => {
+    dispatch({
+        type: SET_USER_LOGIN
+    })
+}

--- a/store/index.js
+++ b/store/index.js
@@ -4,3 +4,6 @@ import { thunk } from 'redux-thunk'
 import rootReducer from './reducers'
 
 export const store = createStore(rootReducer, applyMiddleware(thunk))
+
+export * from './actions'
+export * from './selectors'

--- a/store/reducers/userReducer.js
+++ b/store/reducers/userReducer.js
@@ -1,9 +1,17 @@
+import { SET_USER_LOGIN } from '@constants'
+
 const initalState = {
-    userName: null
+    userName: null,
+    isLoggedIn: false
 }
 
 const userReducer = (state = initalState, action) => {
     switch (action.type) {
+        case SET_USER_LOGIN:
+            return {
+                ...state,
+                isLoggedIn: true
+            }
         default:
             return state
     }

--- a/store/selectors/index.js
+++ b/store/selectors/index.js
@@ -1,0 +1,1 @@
+export * from './userSelectors'

--- a/store/selectors/userSelectors.js
+++ b/store/selectors/userSelectors.js
@@ -1,0 +1,1 @@
+export const selectIsLoggedIn = ({ user }) => user.isLoggedIn


### PR DESCRIPTION
- Define some of the major pages and routes (auth, buy, & sell)
- Navigate between said pages using `expo-router`
- Create some page-wrapping components to handle styling & redirect as needed based on authentication status
- Setup some basic authentication stuff in the `redux` store that we can expand upon later
- Modify build configurations such that we can import from the `components`, `store`, and `constants` directories using `@` instead of some sort of complicated relative path