### PR TITLE
Display order name & other fixes

### DIFF
--- a/app/buy/orderPlaced.js
+++ b/app/buy/orderPlaced.js
@@ -1,6 +1,6 @@
 import { useNavigation } from 'expo-router'
 import React, { useEffect } from 'react'
-import { StyleSheet, Text, View, Alert } from 'react-native'
+import { Alert, StyleSheet, Text, View } from 'react-native'
 import { Button, HelperText } from 'react-native-paper'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -80,7 +80,7 @@ const OrderPlaced = () => {
             <View style={styles.buttonContainer}>
                 <Button
                     onPress={cancel}
-                    mode="contained"
+                    mode="outlined"
                     style={styles.footerButton}
                 >
                     Cancel Order

--- a/app/index.js
+++ b/app/index.js
@@ -43,30 +43,16 @@ const Index = () => {
     }, [])
 
     const name = profileData.firstName
-    const openOrders = profileData.openOrders
-
-    // TODO: open orders need to get updated whenever someone claims/unclaims/places/cancels an order
-    const hasOpenOrders = openOrders && openOrders.length > 0
-    const buttonHeight = hasOpenOrders ? '15%' : '20%'
-    const openOrdersContent = (
-        <>
-            <Divider />
-            <Button
-                url="/openOrders"
-                text="Open Orders"
-                height={buttonHeight}
-            />
-        </>
-    )
 
     return (
         <Page header={name ? `Hello, ${name}!` : 'Hello!'} style={styles.page}>
             <View style={styles.buttonContainer}>
                 <Text style={styles.question}>Would you like to...</Text>
-                <Button url="buy/" text="Buy" height={buttonHeight} />
+                <Button url="buy/" text="Buy" height={'20%'} />
                 <Divider width={'40%'} />
-                <Button url="sell/" text="Sell" height={buttonHeight} />
-                {openOrdersContent}
+                <Button url="sell/" text="Sell" height={'20%'} />
+                <Divider />
+                <Button url="/openOrders" text="Open Orders" height={'20%'} />
             </View>
         </Page>
     )

--- a/app/index.js
+++ b/app/index.js
@@ -44,15 +44,21 @@ const Index = () => {
 
     const name = profileData.firstName
 
+    const buttonHeight = '20%'
+
     return (
         <Page header={name ? `Hello, ${name}!` : 'Hello!'} style={styles.page}>
             <View style={styles.buttonContainer}>
                 <Text style={styles.question}>Would you like to...</Text>
-                <Button url="buy/" text="Buy" height={'20%'} />
+                <Button url="buy/" text="Buy" height={buttonHeight} />
                 <Divider width={'40%'} />
-                <Button url="sell/" text="Sell" height={'20%'} />
+                <Button url="sell/" text="Sell" height={buttonHeight} />
                 <Divider />
-                <Button url="/openOrders" text="Open Orders" height={'20%'} />
+                <Button
+                    url="/openOrders"
+                    text="Open Orders"
+                    height={buttonHeight}
+                />
             </View>
         </Page>
     )

--- a/app/openOrders/index.js
+++ b/app/openOrders/index.js
@@ -1,13 +1,19 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { Text, ScrollView, Image, RefreshControl } from 'react-native'
-import { List } from 'react-native-paper'
 import Ionicons from '@expo/vector-icons/Ionicons'
-import { useRouter, useFocusEffect } from 'expo-router'
+import { useFocusEffect, useRouter } from 'expo-router'
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+    Image,
+    RefreshControl,
+    ScrollView,
+    StyleSheet,
+    Text
+} from 'react-native'
+import { List } from 'react-native-paper'
+import { useDispatch, useSelector } from 'react-redux'
 
-import Page from '@components/Page'
 import LoadingSpinner from '@components/LoadingSpinner'
-import { setActiveOpenOrder, selectOpenOrders, getOpenOrders } from '@store'
+import Page from '@components/Page'
+import { getOpenOrders, selectOpenOrders, setActiveOpenOrder } from '@store'
 
 const OpenOrders = () => {
     const dispatch = useDispatch()
@@ -15,7 +21,7 @@ const OpenOrders = () => {
     const [expandedId, setExpandedId] = useState(null)
     const [refreshing, setRefreshing] = useState(false)
     const [timeInterval, setTimeInterval] = useState(null)
-    const [loading, setLoading] = useState(true)
+    const [loading, setLoading] = useState(false)
 
     const resetRefreshTimer = () => {
         // Refresh orders every 60 seconds
@@ -171,7 +177,11 @@ const OpenOrders = () => {
         </List.AccordionGroup>
     )
 
-    const emptyOrders = <Text>You have no open orders</Text>
+    const emptyOrders = (
+        <Text style={styles.noOrdersText}>You have no open orders.</Text>
+    )
+
+    const hasOrders = orders && orders.length > 0
 
     return (
         <Page header="Open Orders">
@@ -187,12 +197,26 @@ const OpenOrders = () => {
                             colors={['black']}
                         />
                     }
+                    contentContainerStyle={hasOrders ? {} : styles.noOrders}
                 >
-                    {orders && orders.length > 0 ? orderList : emptyOrders}
+                    {hasOrders ? orderList : emptyOrders}
                 </ScrollView>
             )}
         </Page>
     )
 }
+
+const styles = StyleSheet.create({
+    noOrders: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 1
+    },
+    noOrdersText: {
+        fontSize: 24
+    }
+})
 
 export default OpenOrders

--- a/app/openOrders/index.js
+++ b/app/openOrders/index.js
@@ -21,7 +21,7 @@ const OpenOrders = () => {
     const [expandedId, setExpandedId] = useState(null)
     const [refreshing, setRefreshing] = useState(false)
     const [timeInterval, setTimeInterval] = useState(null)
-    const [loading, setLoading] = useState(false)
+    const [loading, setLoading] = useState(true)
 
     const resetRefreshTimer = () => {
         // Refresh orders every 60 seconds

--- a/app/openOrders/orderDetails.js
+++ b/app/openOrders/orderDetails.js
@@ -1,22 +1,34 @@
-import React, { useEffect } from 'react'
-import { ScrollView, Text, StyleSheet, Image, View, Alert } from 'react-native'
-import Page from '@components/Page'
 import {
-    selectActiveOpenOrder,
     cancelOrderBuy,
-    selectOpenOrdersError
+    getOpenOrders,
+    selectActiveOpenOrder,
+    selectOpenOrders,
+    selectOpenOrdersError,
+    selectOpenOrdersLoading,
+    setActiveOpenOrder
 } from '@store'
-import { useSelector, useDispatch } from 'react-redux'
-import Divider from '@components/Divider'
+import { useLocalSearchParams } from 'expo-router'
+import React, { useEffect, useState } from 'react'
+import { Alert, Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { Button } from 'react-native-paper'
-import { useRouter } from 'expo-router'
+import { useDispatch, useSelector } from 'react-redux'
+
+import Divider from '@components/Divider'
+import LoadingSpinner from '@components/LoadingSpinner'
+import Page from '@components/Page'
 
 const OrderDetails = () => {
+    const params = useLocalSearchParams()
+
     const order = useSelector(selectActiveOpenOrder)
+
     const openOrdersError = useSelector(selectOpenOrdersError)
+    const openOrders = useSelector(selectOpenOrders)
+    const openOrdersLoading = useSelector(selectOpenOrdersLoading)
 
     const dispatch = useDispatch()
-    const router = useRouter()
+
+    const [loading, setLoading] = useState(false)
 
     const cancelOrder = () => {
         Alert.alert(
@@ -36,16 +48,38 @@ const OrderDetails = () => {
     }
 
     useEffect(() => {
-        if (!order) {
-            router.back()
+        if (!order && params.id && !openOrdersLoading) {
+            const orderFromParam = openOrders.find(
+                (_order) => _order._id === params.id
+            )
+            if (orderFromParam) {
+                dispatch(setActiveOpenOrder(orderFromParam))
+            }
         }
-    }, [order])
+    }, [order, openOrdersLoading])
 
     useEffect(() => {
         if (openOrdersError) {
             Alert.alert('Error', JSON.stringify(openOrdersError))
         }
     }, [openOrdersError])
+
+    useEffect(() => {
+        if (!openOrders.length) {
+            dispatch(getOpenOrders)
+            setLoading(true)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (loading && !openOrdersLoading) {
+            setLoading(false)
+        }
+    }, [loading, openOrdersLoading])
+
+    if (loading) {
+        return <LoadingSpinner />
+    }
 
     const icons = {
         'Chick-Fil-A': require('@assets/images/icons/Chick-Fil-A.png'),
@@ -140,13 +174,20 @@ const OrderDetails = () => {
                                 Ready at:{' '}
                             </Text>
                             {order.readyTime}
+                            {'\n'}
+                            <Text
+                                style={{
+                                    ...styles.text,
+                                    ...styles.bold
+                                }}
+                            >
+                                Order name:{' '}
+                            </Text>
+                            {order.sellerName}
                         </Text>
                         <Image
                             source={{ uri: order.receiptImage }}
-                            style={{
-                                width: '100%',
-                                height: 400
-                            }}
+                            style={styles.receiptImage}
                             resizeMode="contain"
                         />
                     </>
@@ -168,15 +209,15 @@ const OrderDetails = () => {
             {order ? (
                 content
             ) : (
-                <Text style={styles.errorText}>
-                    An unknown error has occured. Please try again later.
-                </Text>
+                <View style={styles.errorContent}>
+                    <Text style={styles.errorText}>
+                        An unknown error has occured. Please try again later.
+                    </Text>
+                </View>
             )}
         </Page>
     )
 }
-
-export default OrderDetails
 
 const styles = StyleSheet.create({
     buttonContainer: {
@@ -195,7 +236,12 @@ const styles = StyleSheet.create({
         marginBottom: 10
     },
     errorText: {
-        fontSize: 18
+        fontSize: 24
+    },
+    errorContent: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center'
     },
     page: {
         display: 'flex',
@@ -208,5 +254,12 @@ const styles = StyleSheet.create({
     scrollContainer: {
         flexDirection: 'column',
         flex: 1
+    },
+    receiptImage: {
+        width: '100%',
+        height: 400,
+        marginBottom: 10
     }
 })
+
+export default OrderDetails

--- a/app/openOrders/orderDetails.js
+++ b/app/openOrders/orderDetails.js
@@ -48,15 +48,21 @@ const OrderDetails = () => {
     }
 
     useEffect(() => {
-        if (!order && params.id && !openOrdersLoading) {
-            const orderFromParam = openOrders.find(
-                (_order) => _order._id === params.id
-            )
-            if (orderFromParam) {
-                dispatch(setActiveOpenOrder(orderFromParam))
+        if (!openOrdersLoading) {
+            if (!order && params.id) {
+                const orderFromParam = openOrders.find(
+                    (_order) => _order._id === params.id
+                )
+                if (orderFromParam) {
+                    dispatch(setActiveOpenOrder(orderFromParam))
+                }
+            }
+
+            if (loading) {
+                setLoading(false)
             }
         }
-    }, [order, openOrdersLoading])
+    }, [order, openOrdersLoading, loading])
 
     useEffect(() => {
         if (openOrdersError) {
@@ -70,12 +76,6 @@ const OrderDetails = () => {
             setLoading(true)
         }
     }, [])
-
-    useEffect(() => {
-        if (loading && !openOrdersLoading) {
-            setLoading(false)
-        }
-    }, [loading, openOrdersLoading])
 
     if (loading) {
         return <LoadingSpinner />

--- a/app/sell/orderDetails.js
+++ b/app/sell/orderDetails.js
@@ -21,10 +21,10 @@ import {
     selectClaimedOrder,
     selectClaimedOrderError,
     selectClaimedOrderLoading,
-    unclaimOrder,
+    selectOrderConfirmed,
     setReceiptUri as setReceiptUriAction,
     setWaitTime,
-    selectOrderConfirmed
+    unclaimOrder
 } from '@store'
 import { clearRouterStack, formatTimeWithIntl } from '@utils'
 import * as ImagePicker from 'expo-image-picker'
@@ -207,7 +207,7 @@ const OrderDetails = () => {
                 </View>
                 <Divider />
                 <View style={styles.buttonMenu}>
-                    <Button mode="contained" onPress={onUnclaimPress}>
+                    <Button mode="outlined" onPress={onUnclaimPress}>
                         Unclaim Order
                     </Button>
                 </View>

--- a/components/ErrorDialog.js
+++ b/components/ErrorDialog.js
@@ -9,7 +9,8 @@ const ErrorDialog = ({ error, onClose }) => {
                 <Dialog.Title>Error</Dialog.Title>
                 <Dialog.Content>
                     <Text>
-                        An error occurred: {error}. Please try again later.
+                        An error occurred: {error}
+                        {'\n\n'}Please try again later.
                     </Text>
                 </Dialog.Content>
                 <Dialog.Actions>

--- a/store/actions/openOrderActions.js
+++ b/store/actions/openOrderActions.js
@@ -1,8 +1,8 @@
 import {
-    SET_OPEN_ORDERS,
     OPEN_ORDERS_ERROR,
     OPEN_ORDERS_LOADING,
-    SET_ACTIVE_OPEN_ORDER
+    SET_ACTIVE_OPEN_ORDER,
+    SET_OPEN_ORDERS
 } from '@constants'
 
 export const getOpenOrders = async (dispatch, getState) => {
@@ -16,7 +16,7 @@ export const getOpenOrders = async (dispatch, getState) => {
             type: OPEN_ORDERS_LOADING
         })
         const request = await fetch(
-            process.env.EXPO_PUBLIC_API_URL + '/orders/open',
+            `${process.env.EXPO_PUBLIC_API_URL}/orders/open`,
             {
                 method: 'GET',
                 headers: {

--- a/store/actions/payoutActions.js
+++ b/store/actions/payoutActions.js
@@ -48,7 +48,7 @@ export const createPayoutAccount = async (dispatch, getState) => {
 
 export const createPayoutAccountSetupLink = async (dispatch, getState) => {
     const { payout } = getState()
-    if (payout.loading || payout.accountSetupLink) {
+    if (payout.loading) {
         return
     }
 


### PR DESCRIPTION
- Display the order name in `openOrders/orderDetails`
- Update `openOrders/orderDetails` to support an `id` query parameter for push notification linking purposes
- Improve some error messages & no order found messages, especially with regards to styling
- Make some buttons `outlined` instead of `contained` to improve UI/UX
- Make the home page buttons a consistent height
- Make the payout setup link get updated each time; we do not want to re-use a cached value, as this can produce errors