### PR TITLE
Save readyTime as a Date

### DIFF
--- a/app/openOrders/orderDetails.js
+++ b/app/openOrders/orderDetails.js
@@ -17,7 +17,7 @@ import {
     selectOpenOrdersLoading,
     unclaimOrder
 } from '@store'
-import { clearRouterStack } from '@utils'
+import { clearRouterStack, formatTimeWithIntl } from '@utils'
 
 const OrderDetails = () => {
     const navigation = useNavigation()
@@ -213,7 +213,7 @@ const OrderDetails = () => {
                             >
                                 Ready at:{' '}
                             </Text>
-                            {order.readyTime}
+                            {formatTimeWithIntl(order.readyTime)}
                             {'\n'}
                             <Text
                                 style={{

--- a/store/actions/sellActions.js
+++ b/store/actions/sellActions.js
@@ -164,14 +164,7 @@ export const confirmOrder = async (dispatch, getState) => {
     time.setMinutes(time.getMinutes() + sell.claimedOrder.waitTime)
 
     const formData = new FormData()
-    formData.append(
-        'readyTime',
-        time.toLocaleTimeString('en-US', {
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true
-        })
-    )
+    formData.append('readyTime', time.toString())
     formData.append('receipt', {
         uri: sell.claimedOrder.receiptUri,
         name: 'receipt.png',


### PR DESCRIPTION
This is necessary due to [this pull request](https://github.com/meal-match/backend/pull/32). And, honestly, it's an easier and more robust solution.